### PR TITLE
fix: add chr to chromosome numbers when they are missing

### DIFF
--- a/workflow/scripts/padd_target_regions.py
+++ b/workflow/scripts/padd_target_regions.py
@@ -68,7 +68,9 @@ def add_padding(target_bed_df: pd.DataFrame, padding: int) -> pd.DataFrame:
         chrom, start, end, region_id = switch_coordinates_if_reversed(row[0:4])
         start -= padding
         end += padding
-        rows.append([[f"chr{chrom}", start, end, region_id])
+        if (not str(chrom).startswith('chr')):
+            chrom = f"chr{chrom}"
+        rows.append([chrom, start, end, region_id])
     return pd.DataFrame(rows, columns=["CHROM", "START", "END", "ID"])
 
 
@@ -83,5 +85,8 @@ if __name__ == '__main__':
     bed_df = read_df(Path(target_bed))
     padded_coordinates = add_padding(bed_df, int(padding))
 
-    padded_coordinates.to_csv(Path(output_file_name), index=False, sep='\t', header=False)
+    padded_coordinates.to_csv(Path(output_file_name),
+                              index=False,
+                              sep='\t',
+                              header=False)
     logging.info(f"Padded bed file written: {output_file_name}")

--- a/workflow/scripts/padd_target_regions.py
+++ b/workflow/scripts/padd_target_regions.py
@@ -68,7 +68,7 @@ def add_padding(target_bed_df: pd.DataFrame, padding: int) -> pd.DataFrame:
         chrom, start, end, region_id = switch_coordinates_if_reversed(row[0:4])
         start -= padding
         end += padding
-        rows.append([chrom, start, end, region_id])
+        rows.append([[f"chr{chrom}", start, end, region_id])
     return pd.DataFrame(rows, columns=["CHROM", "START", "END", "ID"])
 
 

--- a/workflow/scripts/padd_target_regions_test.py
+++ b/workflow/scripts/padd_target_regions_test.py
@@ -96,6 +96,14 @@ class TestAddPadding(unittest.TestCase):
                                     columns=["CHROM", "START", "END", "ID"])
         unpadded_bed = unpadded_bed.astype({"START": int, "END": int})
 
+        unpadded_bed_chr_missing = pd.DataFrame(
+            [["1", "200", "300", "ID1"]],
+            columns=["CHROM", "START", "END", "ID"])
+        unpadded_bed_chr_missing = unpadded_bed.astype({
+            "START": int,
+            "END": int
+        })
+
         padded_bed = pd.DataFrame([["chr1", "100", "400", "ID1"]],
                                   columns=["CHROM", "START", "END", "ID"])
         padded_bed = padded_bed.astype({"START": int, "END": int})
@@ -104,6 +112,12 @@ class TestAddPadding(unittest.TestCase):
             TestCase(
                 name="Pad coordinates successfully",
                 input=unpadded_bed,
+                padding=100,
+                expected=padded_bed,
+            ),
+            TestCase(
+                name="Pad coordinates successfully",
+                input=unpadded_bed_chr_missing,
                 padding=100,
                 expected=padded_bed,
             ),


### PR DESCRIPTION
This PR adds "chr" to chromosome numbers when the padded bed file is lacking them.

Closes: #11 